### PR TITLE
Fix bug where all default security group rules are revoked

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -135,9 +135,10 @@ module "vpc" {
     "kubernetes.io/role/elb" = "1"
   }
 
-  enable_nat_gateway   = true
-  enable_dns_hostnames = true
-  enable_dns_support   = true
+  enable_nat_gateway            = true
+  enable_dns_hostnames          = true
+  enable_dns_support            = true
+  manage_default_security_group = false
 
   tags = {
     Terraform    = "true"


### PR DESCRIPTION
In v4.0.0 of the vpc module we use, manage_default_security_group now
defaults to true (https://github.com/terraform-aws-modules/terraform-aws-vpc/releases/tag/v4.0.0).

This has the effect of immediately revoking all inbound/outbound
security group rules on the default security group, which is not
suitable for HyperShift until OCPBUGS-11894 is fixed and released.