### PR TITLE
modified for ap-northeast-1  multi AZ enviroment

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@
 | Name | Version |
 |------|---------|
 | aws | 4.67.0 |
-| null | 3.2.1 |
+| null | 3.2.2 |
 
 ## Modules
 
@@ -63,6 +63,7 @@
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | cluster\_name | Name of the created ROSA with hosted control planes cluster. | `string` | `"rosa-hcp"` | no |
+| extra\_tags | Extra tags to apply to AWS resources | `map` | `{}` | no |
 | private\_subnets\_only | Only create private subnets | `bool` | `false` | no |
 | region | Region to create AWS infrastructure resources for a<br>  ROSA with hosted control planes cluster. (required) | `string` | n/a | yes |
 | single\_az\_only | Only create subnets in a single availability zone | `bool` | `true` | no |

--- a/main.tf
+++ b/main.tf
@@ -15,6 +15,7 @@ locals {
   }
   well_known_az_ids = {
     us-east-1 = [2, 4, 6]
+    ap-northeast-1 = [1, 2, 4]
   }
   az_id_prefix = lookup(local.supported_regions, var.region, null) != null ? "${local.supported_regions[var.region]}-az" : "unknown-az"
   azs = (


### PR DESCRIPTION
Hello, `terraform plan` command with multi az option (`-var single_az_only=false`)  for ap-northeast-1 wasn't working.

```
$  terraform plan -out rosa.tfplan -var region=ap-northeast-1 -var cluster_name=myhcp -var single_az_only=false
data.aws_availability_zones.available_azs: Reading...
data.aws_availability_zones.available_azs: Read complete after 0s [id=ap-northeast-1]

Planning failed. Terraform encountered an error while generating this plan.

╷
│ Error: Resource precondition failed
│
│   on main.tf line 106, in resource "null_resource" "validations":
│  106:       condition     = alltrue([for id in local.az_ids : contains(data.aws_availability_zones.available_azs.zone_ids, id)])
│     ├────────────────
│     │ data.aws_availability_zones.available_azs.zone_ids is list of string with 3 elements
│     │ local.az_ids is tuple with 3 elements
│
│ ROSA with hosted control planes in region ap-northeast-1 does not currently support availability zone ID(s):
│   apne1-az3
╵
```

It seemes that the  `main.tf` was expecting below AZ IDs.

```
・apne1-az1
・apne1-az2
・apne1-az3
```

But in ap-northeast-1 region, apne1-az3 had been closed a long time ago.  The current available AZ IDs are...

```
・apnet1-az1
・apnet1-az2
・apnet1-az4
```

So, there was a mismatch between the `main.tf `and the available AZ IDs in ap-northeast-1

As I looked at the `main.tf`, I felt `the well_known_az_ids` seemed a good position to accommodate the ap-northeast-1 difference. So, I modified it like below.

```
  well_known_az_ids = {
    us-east-1 = [2, 4, 6]
    ap-northeast-1 = [1, 2, 4]   # added for ap-northeast-1
  }
```

I tested it, and it's all working fine. It doesn't seem to have side effects.
But I am not so familiar with HCL. So, I would appreciate it if you check the modification.